### PR TITLE
RHDHPAI-64: update kfmr to include URLs from Kserve

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -77,17 +77,17 @@ vendored dependencies:
 
 ## New 'Model Metadata' sources
 
-| Source      | Summary/REST/CRDs                | Questions/Comments                                            | Priority | Tracker                                              | Status  |
-|-------------|----------------------------------|---------------------------------------------------------------|----------|------------------------------------------------------|---------|
-| Kubeflow    | Endpoint URL.  Has both REST/CRD | RHOAI Jira marked done.  Which version?  End to end examples? | high     | [Jira](https://issues.redhat.com/browse/RHDHPAI-64)  | waiting |
-| 3Scale      | All data ready.  Yes REST/CRDs   | Perhaps the next highest item. Devex vs. RHOAI priorities     | high     | [Jira](https://issues.redhat.com/browse/RHDHPAI-65)  | new     |
-| HuggingFace | All data ready.  REST only       | Most popular source for public models. Best for tech docs     |          | [Jira](https://issues.redhat.com/browse/RHDHPAI-667) | new     |
-| MLFlow      | All data ready.  REST only       | Mature. KServe support. ai-on-openshift.io refs. Competitor?  |          |                                                      | new     |
-| Ollama      | All data ready.  REST only       | RHDH AI/Devex use vs. RHOAI sanctioned, indemnification       |          | [Jira](https://issues.redhat.com/browse/RHDHPAI-66)  | new     |
-| OCI         | Endpoint URL ? REST, 'oc image'  | Often cited at strategy level. Requires coupling with ?       | high     |                                                      | new     |
-| Open WebUI  | All data ready.  REST only       | Competition? But supports Kubernetes.                         |          |                                                      | new     |
-|             |                                  |                                                               |          |                                                      |         |
-|             |                                  |                                                               |          |                                                      |         |
+| Source      | Summary/REST/CRDs                | Questions/Comments                                                                                                         | Priority | Tracker                                              | Status      |
+|-------------|----------------------------------|----------------------------------------------------------------------------------------------------------------------------|----------|------------------------------------------------------|-------------|
+| Kubeflow    | Endpoint URL.  Has both REST/CRD | Opened [this RFE](https://issues.redhat.com/browse/RHOAIENG-16898) for RHOAI to better optimize route retrieval for 'bac'  | high     | [Jira](https://issues.redhat.com/browse/RHDHPAI-64)  | implemented |
+| 3Scale      | All data ready.  Yes REST/CRDs   | Perhaps the next highest item. Devex vs. RHOAI priorities                                                                  | high     | [Jira](https://issues.redhat.com/browse/RHDHPAI-65)  | new         |
+| HuggingFace | All data ready.  REST only       | Most popular source for public models. Best for tech docs                                                                  |          | [Jira](https://issues.redhat.com/browse/RHDHPAI-667) | new         |
+| MLFlow      | All data ready.  REST only       | Mature. KServe support. ai-on-openshift.io refs. Competitor?                                                               |          |                                                      | new         |
+| Ollama      | All data ready.  REST only       | RHDH AI/Devex use vs. RHOAI sanctioned, indemnification                                                                    |          | [Jira](https://issues.redhat.com/browse/RHDHPAI-66)  | new         |
+| OCI         | Endpoint URL ? REST, 'oc image'  | Often cited at strategy level. Requires coupling with ?                                                                    | high     |                                                      | new         |
+| Open WebUI  | All data ready.  REST only       | Competition? But supports Kubernetes.                                                                                      |          |                                                      | new         |
+|             |                                  |                                                                                                                            |          |                                                      |             |
+|             |                                  |                                                                                                                            |          |                                                      |             |
 
 ## TechDocs
 

--- a/pkg/cmd/cli/backstage/constants.go
+++ b/pkg/cmd/cli/backstage/constants.go
@@ -10,6 +10,7 @@ const (
 	GRAPHQL_API_TYPE   = "graphql"
 	GRPC_API_TYPE      = "grpc"
 	TRPC_API_TYPE      = "trpc"
+	UNKNOWN_API_TYPE   = "unknown"
 	LINK_API_URL       = "API URL"
 	LINK_TYPE_WEBSITE  = "website"
 	LINK_ICON_WEBASSET = "WebAsset"

--- a/pkg/cmd/cli/backstage/interfaces.go
+++ b/pkg/cmd/cli/backstage/interfaces.go
@@ -110,6 +110,8 @@ func PrintAPI(pop APIPopulator, cmd *cobra.Command) error {
 		api.Spec.Type = TRPC_API_TYPE
 	case strings.Contains(api.Spec.Definition, "proto"):
 		api.Spec.Type = GRPC_API_TYPE
+	default:
+		api.Spec.Type = UNKNOWN_API_TYPE
 	}
 
 	err := util.PrintYaml(api, false, cmd)

--- a/pkg/cmd/cli/kserve/kserve.go
+++ b/pkg/cmd/cli/kserve/kserve.go
@@ -18,21 +18,21 @@ import (
 
 const (
 	kserveExamples = `
-# Both owner and lifecycle are required parameters.  Examine Backstage Catalog documentation for details.
+# Both Owner and Lifecycle are required parameters.  Examine Backstage Catalog documentation for details.
 # This will query all the InferenceService instances in the current namespace and build Catalog Component, Resource, and
 # API Entities from the data.
-$ %s new-model kserve <owner> <lifecycle> <args...>
+$ %s new-model kserve <Owner> <Lifecycle> <args...>
 
 # This example shows the flags that will set the URL, Token, and Skip TLS when accessing the cluster for InferenceService instances 
-$ %s new-model kserve <owner> <lifecycle> --model-metadata-url=https://my-kubeflow.com --model-metadata-token=my-token --model-metadata-skip-tls=true
+$ %s new-model kserve <Owner> <Lifecycle> --model-metadata-url=https://my-kubeflow.com --model-metadata-token=my-token --model-metadata-skip-tls=true
 
 # The '--kubeconfig' flag can be used to set the location of the configuration file used for accessing the credentials
 # used for interacting with the Kubernetes cluster.
-$ %s new-model kserve <owner> <lifecycle> --kubeconfig=/home/myid/my-kube.json
+$ %s new-model kserve <Owner> <Lifecycle> --kubeconfig=/home/myid/my-kube.json
 
 # This form will pull in only the InferenceService instances with the names 'inferenceservice1' and 'inferenceservice2'
 # in the 'my-datascience-project'namespace in order to build Catalog Component, Resource, and API Entities.
-$ %s new-model kserve owner lifecycle inferenceservice1 inferenceservice2 --namespace my-datascience-project
+$ %s new-model kserve Owner Lifecycle inferenceservice1 inferenceservice2 --namespace my-datascience-project
 `
 	sklearn     = "sklearn"
 	xgboost     = "xgboost"
@@ -46,38 +46,38 @@ $ %s new-model kserve owner lifecycle inferenceservice1 inferenceservice2 --name
 	paddle      = "paddle"
 )
 
-type commonPopulator struct {
-	owner     string
-	lifecycle string
-	is        *serverapiv1beta1.InferenceService
+type CommonPopulator struct {
+	Owner     string
+	Lifecycle string
+	InferSvc  *serverapiv1beta1.InferenceService
 }
 
-func (pop *commonPopulator) GetOwner() string {
-	return pop.owner
+func (pop *CommonPopulator) GetOwner() string {
+	return pop.Owner
 }
 
-func (pop *commonPopulator) GetLifecycle() string {
-	return pop.lifecycle
+func (pop *CommonPopulator) GetLifecycle() string {
+	return pop.Lifecycle
 }
 
-func (pop *commonPopulator) GetName() string {
-	return fmt.Sprintf("%s_%s", pop.is.Namespace, pop.is.Name)
+func (pop *CommonPopulator) GetName() string {
+	return fmt.Sprintf("%s_%s", pop.InferSvc.Namespace, pop.InferSvc.Name)
 }
-func (pop *commonPopulator) GetDescription() string {
-	return fmt.Sprintf("KServe instance %s:%s", pop.is.Namespace, pop.is.Name)
+func (pop *CommonPopulator) GetDescription() string {
+	return fmt.Sprintf("KServe instance %s:%s", pop.InferSvc.Namespace, pop.InferSvc.Name)
 }
 
-func (pop *commonPopulator) GetLinks() []backstage.EntityLink {
+func (pop *CommonPopulator) GetLinks() []backstage.EntityLink {
 	links := []backstage.EntityLink{}
-	if pop.is.Status.URL != nil {
+	if pop.InferSvc.Status.URL != nil {
 		links = append(links, backstage.EntityLink{
-			URL:   pop.is.Status.URL.String(),
+			URL:   pop.InferSvc.Status.URL.String(),
 			Title: backstage.LINK_API_URL,
 			Type:  backstage.LINK_TYPE_WEBSITE,
 			Icon:  backstage.LINK_ICON_WEBASSET,
 		})
 	}
-	for componentType, componentStatus := range pop.is.Status.Components {
+	for componentType, componentStatus := range pop.InferSvc.Status.Components {
 
 		if componentStatus.URL != nil {
 			links = append(links, backstage.EntityLink{
@@ -113,9 +113,9 @@ func (pop *commonPopulator) GetLinks() []backstage.EntityLink {
 	return links
 }
 
-func (pop *commonPopulator) GetTags() []string {
+func (pop *CommonPopulator) GetTags() []string {
 	tags := []string{}
-	predictor := pop.is.Spec.Predictor
+	predictor := pop.InferSvc.Spec.Predictor
 	// one and only one predictor spec can be set
 	switch {
 	case predictor.SKLearn != nil:
@@ -157,23 +157,23 @@ func (pop *commonPopulator) GetTags() []string {
 		tag = strings.ToLower(tag)
 		tags = append(tags, tag)
 	}
-	explainer := pop.is.Spec.Explainer
+	explainer := pop.InferSvc.Spec.Explainer
 	if explainer != nil && explainer.ART != nil {
 		tags = append(tags, strings.ToLower(string(explainer.ART.Type)))
 	}
 	return tags
 }
 
-func (pop *commonPopulator) GetProvidedAPIs() []string {
-	return []string{fmt.Sprintf("%s_%s", pop.is.Namespace, pop.is.Name)}
+func (pop *CommonPopulator) GetProvidedAPIs() []string {
+	return []string{fmt.Sprintf("%s_%s", pop.InferSvc.Namespace, pop.InferSvc.Name)}
 }
 
 type componentPopulator struct {
-	commonPopulator
+	CommonPopulator
 }
 
 func (pop *componentPopulator) GetDependsOn() []string {
-	return []string{fmt.Sprintf("resource:%s_%s", pop.is.Namespace, pop.is.Name), fmt.Sprintf("api:%s_%s", pop.is.Namespace, pop.is.Name)}
+	return []string{fmt.Sprintf("resource:%s_%s", pop.InferSvc.Namespace, pop.InferSvc.Name), fmt.Sprintf("api:%s_%s", pop.InferSvc.Namespace, pop.InferSvc.Name)}
 }
 
 func (pop *componentPopulator) GetTechdocRef() string {
@@ -185,11 +185,11 @@ func (pop *componentPopulator) GetDisplayName() string {
 }
 
 type resourcePopulator struct {
-	commonPopulator
+	CommonPopulator
 }
 
 func (pop *resourcePopulator) GetDependencyOf() []string {
-	return []string{fmt.Sprintf("component:%s_%s", pop.is.Namespace, pop.is.Name)}
+	return []string{fmt.Sprintf("component:%s_%s", pop.InferSvc.Namespace, pop.InferSvc.Name)}
 }
 
 func (pop *resourcePopulator) GetTechdocRef() string {
@@ -201,18 +201,18 @@ func (pop *resourcePopulator) GetDisplayName() string {
 }
 
 type apiPopulator struct {
-	commonPopulator
+	CommonPopulator
 }
 
 func (pop *apiPopulator) GetDependencyOf() []string {
-	return []string{fmt.Sprintf("component:%s_%s", pop.is.Namespace, pop.is.Name)}
+	return []string{fmt.Sprintf("component:%s_%s", pop.InferSvc.Namespace, pop.InferSvc.Name)}
 }
 
 func (pop *apiPopulator) GetDefinition() string {
-	if pop.is.Status.URL == nil {
+	if pop.InferSvc.Status.URL == nil {
 		return ""
 	}
-	defBytes, _ := util.FetchURL(pop.is.Status.URL.String() + "/openapi.json")
+	defBytes, _ := util.FetchURL(pop.InferSvc.Status.URL.String() + "/openapi.json")
 	dst := bytes.Buffer{}
 	json.Indent(&dst, defBytes, "", "    ")
 	return dst.String()
@@ -228,7 +228,7 @@ func (pop *apiPopulator) GetDisplayName() string {
 
 func SetupKServeClient(cfg *config.Config) {
 	if cfg == nil {
-		klog.Error("Command config is nil")
+		klog.Error("Command config InferSvc nil")
 		klog.Flush()
 		os.Exit(1)
 	}
@@ -261,7 +261,7 @@ func NewCmd(cfg *config.Config) *cobra.Command {
 			ids := []string{}
 
 			if len(args) < 2 {
-				err := fmt.Errorf("need to specify an owner and lifecycle setting")
+				err := fmt.Errorf("need to specify an Owner and Lifecycle setting")
 				klog.Errorf("%s", err.Error())
 				klog.Flush()
 				return err
@@ -316,27 +316,27 @@ func NewCmd(cfg *config.Config) *cobra.Command {
 
 func callBackstagePrinters(owner, lifecycle string, is *serverapiv1beta1.InferenceService, cmd *cobra.Command) error {
 	compPop := componentPopulator{}
-	compPop.owner = owner
-	compPop.lifecycle = lifecycle
-	compPop.is = is
+	compPop.Owner = owner
+	compPop.Lifecycle = lifecycle
+	compPop.InferSvc = is
 	err := backstage.PrintComponent(&compPop, cmd)
 	if err != nil {
 		return err
 	}
 
 	resPop := resourcePopulator{}
-	resPop.owner = owner
-	resPop.lifecycle = lifecycle
-	resPop.is = is
+	resPop.Owner = owner
+	resPop.Lifecycle = lifecycle
+	resPop.InferSvc = is
 	err = backstage.PrintResource(&resPop, cmd)
 	if err != nil {
 		return err
 	}
 
 	apiPop := apiPopulator{}
-	apiPop.owner = owner
-	apiPop.lifecycle = lifecycle
-	apiPop.is = is
+	apiPop.Owner = owner
+	apiPop.Lifecycle = lifecycle
+	apiPop.InferSvc = is
 	err = backstage.PrintAPI(&apiPop, cmd)
 	return err
 }

--- a/pkg/cmd/cli/kserve/kserve_test.go
+++ b/pkg/cmd/cli/kserve/kserve_test.go
@@ -41,39 +41,39 @@ func TestNewCmd(t *testing.T) {
 			name:           "no args",
 			args:           []string{},
 			generatesError: true,
-			errorStr:       "need to specify an owner and lifecycle setting",
+			errorStr:       "need to specify an Owner and Lifecycle setting",
 		},
 		{
-			name:           "owner only",
-			args:           []string{"owner"},
+			name:           "Owner only",
+			args:           []string{"Owner"},
 			generatesError: true,
-			errorStr:       "need to specify an owner and lifecycle setting",
+			errorStr:       "need to specify an Owner and Lifecycle setting",
 		},
 		{
-			name: "owner and lifecycle but no data",
-			args: []string{"owner", "lifecycle"},
+			name: "Owner and Lifecycle but no data",
+			args: []string{"Owner", "Lifecycle"},
 		},
 		{
-			name: "owner and lifecycle and data but no url",
-			args: []string{"owner", "lifecycle"},
+			name: "Owner and Lifecycle and data but no url",
+			args: []string{"Owner", "Lifecycle"},
 			is: []serverapiv1beta1.InferenceService{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: metav1.NamespaceDefault,
-						Name:      "is-1",
+						Name:      "InferSvc-1",
 					},
 				},
 			},
 			outStr: []string{urlNotSet},
 		},
 		{
-			name: "owner and lifecycle set and data and url",
-			args: []string{"owner", "lifecycle"},
+			name: "Owner and Lifecycle set and data and url",
+			args: []string{"Owner", "Lifecycle"},
 			is: []serverapiv1beta1.InferenceService{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: metav1.NamespaceDefault,
-						Name:      "is-1",
+						Name:      "InferSvc-1",
 					},
 					Status: serverapiv1beta1.InferenceServiceStatus{
 						URL: &apis.URL{
@@ -87,12 +87,12 @@ func TestNewCmd(t *testing.T) {
 		},
 		{
 			name: "use everything including bunch of tags",
-			args: []string{"owner", "lifecycle"},
+			args: []string{"Owner", "Lifecycle"},
 			is: []serverapiv1beta1.InferenceService{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: metav1.NamespaceDefault,
-						Name:      "is-1",
+						Name:      "InferSvc-1",
 					},
 					Status: serverapiv1beta1.InferenceServiceStatus{
 						URL: &apis.URL{
@@ -104,7 +104,7 @@ func TestNewCmd(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: metav1.NamespaceDefault,
-						Name:      "is-2",
+						Name:      "InferSvc-2",
 					},
 					Spec: serverapiv1beta1.InferenceServiceSpec{
 						Predictor: serverapiv1beta1.PredictorSpec{
@@ -189,12 +189,12 @@ func TestNewCmd(t *testing.T) {
 		},
 		{
 			name: "fetch 2 specific inferenceservices",
-			args: []string{"owner", "lifecycle", "is-1", "is-2"},
+			args: []string{"Owner", "Lifecycle", "InferSvc-1", "InferSvc-2"},
 			is: []serverapiv1beta1.InferenceService{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: metav1.NamespaceDefault,
-						Name:      "is-1",
+						Name:      "InferSvc-1",
 					},
 					Status: serverapiv1beta1.InferenceServiceStatus{
 						URL: &apis.URL{
@@ -206,7 +206,7 @@ func TestNewCmd(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: metav1.NamespaceDefault,
-						Name:      "is-2",
+						Name:      "InferSvc-2",
 					},
 					Spec: serverapiv1beta1.InferenceServiceSpec{
 						Predictor: serverapiv1beta1.PredictorSpec{
@@ -331,18 +331,18 @@ kind: Component
 metadata:
   annotations:
     backstage.io/techdocs-ref: ./
-  description: KServe instance default:is-1
-  name: default_is-1
+  description: KServe instance default:InferSvc-1
+  name: default_InferSvc-1
 spec:
   dependsOn:
-  - resource:default_is-1
-  - api:default_is-1
-  lifecycle: lifecycle
-  owner: user:owner
+  - resource:default_InferSvc-1
+  - api:default_InferSvc-1
+  lifecycle: Lifecycle
+  owner: user:Owner
   profile:
-    displayName: default_is-1
+    displayName: default_InferSvc-1
   providesApis:
-  - default_is-1
+  - default_InferSvc-1
   type: model-server
 ---
 apiVersion: backstage.io/v1alpha1
@@ -350,17 +350,17 @@ kind: Resource
 metadata:
   annotations:
     backstage.io/techdocs-ref: resource/
-  description: KServe instance default:is-1
-  name: default_is-1
+  description: KServe instance default:InferSvc-1
+  name: default_InferSvc-1
 spec:
   dependencyOf:
-  - component:default_is-1
-  lifecycle: lifecycle
-  owner: user:owner
+  - component:default_InferSvc-1
+  lifecycle: Lifecycle
+  owner: user:Owner
   profile:
-    displayName: default_is-1
+    displayName: default_InferSvc-1
   providesApis:
-  - default_is-1
+  - default_InferSvc-1
   type: ai-model
 ---
 apiVersion: backstage.io/v1alpha1
@@ -368,40 +368,40 @@ kind: API
 metadata:
   annotations:
     backstage.io/techdocs-ref: api/
-  description: KServe instance default:is-1
-  name: default_is-1
+  description: KServe instance default:InferSvc-1
+  name: default_InferSvc-1
 spec:
   definition: ""
   dependencyOf:
-  - component:default_is-1
-  lifecycle: lifecycle
-  owner: user:owner
+  - component:default_InferSvc-1
+  lifecycle: Lifecycle
+  owner: user:Owner
   profile:
-    displayName: default_is-1
-  type: ""
+    displayName: default_InferSvc-1
+  type: unknown
 `
 	urlSet = `apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
   annotations:
     backstage.io/techdocs-ref: ./
-  description: KServe instance default:is-1
+  description: KServe instance default:InferSvc-1
   links:
   - icon: WebAsset
     title: API URL
     type: website
     url: https://kserve.com
-  name: default_is-1
+  name: default_InferSvc-1
 spec:
   dependsOn:
-  - resource:default_is-1
-  - api:default_is-1
-  lifecycle: lifecycle
-  owner: user:owner
+  - resource:default_InferSvc-1
+  - api:default_InferSvc-1
+  lifecycle: Lifecycle
+  owner: user:Owner
   profile:
-    displayName: default_is-1
+    displayName: default_InferSvc-1
   providesApis:
-  - default_is-1
+  - default_InferSvc-1
   type: model-server
 ---
 apiVersion: backstage.io/v1alpha1
@@ -409,22 +409,22 @@ kind: Resource
 metadata:
   annotations:
     backstage.io/techdocs-ref: resource/
-  description: KServe instance default:is-1
+  description: KServe instance default:InferSvc-1
   links:
   - icon: WebAsset
     title: API URL
     type: website
     url: https://kserve.com
-  name: default_is-1
+  name: default_InferSvc-1
 spec:
   dependencyOf:
-  - component:default_is-1
-  lifecycle: lifecycle
-  owner: user:owner
+  - component:default_InferSvc-1
+  lifecycle: Lifecycle
+  owner: user:Owner
   profile:
-    displayName: default_is-1
+    displayName: default_InferSvc-1
   providesApis:
-  - default_is-1
+  - default_InferSvc-1
   type: ai-model
 ---
 apiVersion: backstage.io/v1alpha1
@@ -432,25 +432,25 @@ kind: API
 metadata:
   annotations:
     backstage.io/techdocs-ref: api/
-  description: KServe instance default:is-1
+  description: KServe instance default:InferSvc-1
   links:
   - icon: WebAsset
     title: API URL
     type: website
     url: https://kserve.com
-  name: default_is-1
+  name: default_InferSvc-1
 spec:
   definition: ""
   dependencyOf:
-  - component:default_is-1
-  lifecycle: lifecycle
-  owner: user:owner
+  - component:default_InferSvc-1
+  lifecycle: Lifecycle
+  owner: user:Owner
   profile:
-    displayName: default_is-1
-  type: ""
+    displayName: default_InferSvc-1
+  type: unknown
 `
 
-	description2 = "description: KServe instance default:is-2"
+	description2 = "description: KServe instance default:InferSvc-2"
 	link21       = `  - icon: WebAsset
     title: API URL
     type: website
@@ -516,7 +516,7 @@ spec:
     type: website
     url: https://kserve.com/grpc
 `
-	nameTags2 = `  name: default_is-2
+	nameTags2 = `  name: default_InferSvc-2
   tags:
   - sklearn
   - xgboost
@@ -533,35 +533,35 @@ spec:
 `
 	compSpec2 = `spec:
   dependsOn:
-  - resource:default_is-2
-  - api:default_is-2
-  lifecycle: lifecycle
-  owner: user:owner
+  - resource:default_InferSvc-2
+  - api:default_InferSvc-2
+  lifecycle: Lifecycle
+  owner: user:Owner
   profile:
-    displayName: default_is-2
+    displayName: default_InferSvc-2
   providesApis:
-  - default_is-2
+  - default_InferSvc-2
   type: model-server
 `
 	resourceSpec2 = `spec:
   dependencyOf:
-  - component:default_is-2
-  lifecycle: lifecycle
-  owner: user:owner
+  - component:default_InferSvc-2
+  lifecycle: Lifecycle
+  owner: user:Owner
   profile:
-    displayName: default_is-2
+    displayName: default_InferSvc-2
   providesApis:
-  - default_is-2
+  - default_InferSvc-2
   type: ai-model
 `
 	apiSpec2 = `spec:
   definition: ""
   dependencyOf:
-  - component:default_is-2
-  lifecycle: lifecycle
-  owner: user:owner
+  - component:default_InferSvc-2
+  lifecycle: Lifecycle
+  owner: user:Owner
   profile:
-    displayName: default_is-2
-  type: ""
+    displayName: default_InferSvc-2
+  type: unknown
 `
 )

--- a/pkg/cmd/cli/kubeflowmodelregistry/inferenceservice.go
+++ b/pkg/cmd/cli/kubeflowmodelregistry/inferenceservice.go
@@ -1,0 +1,21 @@
+package kubeflowmodelregistry
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/kubeflow/model-registry/pkg/openapi"
+)
+
+func (k *KubeFlowRESTClientWrapper) ListInferenceServices() ([]openapi.InferenceService, error) {
+	buf, err := k.getFromModelRegistry(k.RootURL + fmt.Sprintf(LIST_INFERENCE_SERVICES_URI))
+	if err != nil {
+		return nil, err
+	}
+
+	mas := openapi.InferenceServiceList{}
+	err = json.Unmarshal(buf, &mas)
+	if err != nil {
+		return nil, err
+	}
+	return mas.Items, err
+}

--- a/pkg/cmd/cli/kubeflowmodelregistry/kfmr_test.go
+++ b/pkg/cmd/cli/kubeflowmodelregistry/kfmr_test.go
@@ -26,12 +26,12 @@ func TestNewCmd(t *testing.T) {
 		{
 			args:           []string{},
 			generatesError: true,
-			errorStr:       "need to specify an owner and lifecycle setting",
+			errorStr:       "need to specify an Owner and Lifecycle setting",
 		},
 		{
 			args:           []string{"owner"},
 			generatesError: true,
-			errorStr:       "need to specify an owner and lifecycle setting",
+			errorStr:       "need to specify an Owner and Lifecycle setting",
 		},
 		{
 			args:   []string{"owner", "lifecycle"},
@@ -78,6 +78,11 @@ metadata:
   annotations:
     backstage.io/techdocs-ref: ./
   description: dummy model 1
+  links:
+  - icon: WebAsset
+    title: version 1
+    type: website
+    url: https://foo.com
   name: model-1
   tags:
   - foo:&{bar MetadataStringValue}
@@ -118,7 +123,7 @@ metadata:
   annotations:
     backstage.io/techdocs-ref: api/
   description: dummy model 1
-  name: model-1-v1-artifact
+  name: model-1
 spec:
   definition: no-definition-yet
   dependencyOf:
@@ -126,7 +131,7 @@ spec:
   lifecycle: lifecycle
   owner: user:kube:admin
   profile:
-    displayName: model-1-v1-artifact
-  type: ""
+    displayName: model-1
+  type: unknown
 `
 )

--- a/pkg/cmd/cli/kubeflowmodelregistry/servingenvironment.go
+++ b/pkg/cmd/cli/kubeflowmodelregistry/servingenvironment.go
@@ -1,0 +1,21 @@
+package kubeflowmodelregistry
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/kubeflow/model-registry/pkg/openapi"
+)
+
+func (k *KubeFlowRESTClientWrapper) GetServingEnvironment(id string) (*openapi.ServingEnvironment, error) {
+	buf, err := k.getFromModelRegistry(k.RootURL + fmt.Sprintf(GET_SERVING_ENV_URI, id))
+	if err != nil {
+		return nil, err
+	}
+
+	se := &openapi.ServingEnvironment{}
+	err = json.Unmarshal(buf, se)
+	if err != nil {
+		return nil, err
+	}
+	return se, err
+}

--- a/pkg/cmd/cli/root_test.go
+++ b/pkg/cmd/cli/root_test.go
@@ -24,12 +24,12 @@ func TestNewCmd(t *testing.T) {
 		{
 			args:           []string{"new-model", "kserve"},
 			generatesError: true,
-			errorStr:       "need to specify an owner and lifecycle setting",
+			errorStr:       "need to specify an Owner and Lifecycle setting",
 		},
 		{
 			args:           []string{"new-model", "kubeflow"},
 			generatesError: true,
-			errorStr:       "need to specify an owner and lifecycle setting",
+			errorStr:       "need to specify an Owner and Lifecycle setting",
 		},
 		{
 			args:          []string{"new-model", "help", "kserve"},


### PR DESCRIPTION
So when ODH can reconcile KServe InferenceServices to the model registry equivalents, we can then get the namespace/name of InferenceServices mapped to the registered models, and fetch the URLs

We have opened a RFE for the RHOAI folks to save the URLs as custom properties on the model registry inferences service so we don't have to do the k8s/ocp lookup.